### PR TITLE
Minor cleanups

### DIFF
--- a/ZDD/jl_zdd/graveyard.jl
+++ b/ZDD/jl_zdd/graveyard.jl
@@ -1,0 +1,60 @@
+### This is where unused functions go to die.
+
+function update_comp_assign!(node::Node, vertex_comp::UInt8)::UInt8
+    """
+    """
+    indexes = Vector{UInt8}(undef, 0)
+    for (i, item) in enumerate(node.comp_assign)
+        if item == vertex_comp
+            push!(indexes, i)
+        end
+    end
+    new_max = maximum(indexes)
+
+    for i in indexes
+        node.comp_assign[i] = new_max
+    end
+    return new_max
+end
+
+function update_comp!(node::Node, vertex_comp::UInt8, new_max::UInt8)
+    filter!(x -> x != vertex_comp, node.comp)
+    push!(node.comp, new_max)
+    sort!(node.comp) # needed for Node equality to increase Node merges
+end
+
+function update_comp_weights!(node::Node, vertex_comp::UInt8, new_max::UInt8)
+    if new_max != vertex_comp
+        node.comp_weights[new_max] = node.comp_weights[vertex_comp]
+        node.comp_weights[vertex_comp] = 0
+    end
+end
+
+function adjust_node!(node::Node, vertex_comp::UInt8, fp_container::Vector{ForbiddenPair})
+    """
+    """
+    if vertex_comp in node.comp_assign
+        # there is atleast one lower vertex number that has the higher comp
+        # number and needs to be adjusted
+        new_max = update_comp_assign!(node, vertex_comp)
+        update_comp!(node, vertex_comp, new_max)
+        update_comp_weights!(node, vertex_comp, new_max)
+
+        # change ForbiddenPair
+        for fp in node.fps
+            if vertex_comp == fp.comp₁
+                other = fp.comp₂
+                delete!(node.fps, fp)
+                push!(fp_container, ForbiddenPair(min(new_max, other), max(new_max, other)))
+            elseif vertex_comp == fp.comp₂
+                other = fp.comp₁
+                delete!(node.fps, fp)
+                push!(fp_container, ForbiddenPair(min(new_max, other), max(new_max, other)))
+            end
+        end
+        for fp in fp_container
+            push!(node.fps, fp)
+        end
+    end
+    empty!(fp_container)
+end

--- a/ZDD/jl_zdd/node.jl
+++ b/ZDD/jl_zdd/node.jl
@@ -33,7 +33,7 @@ Base.hash(fp::ForbiddenPair, h::UInt) = hash(fp.comp₁, hash(fp.comp₂, hash(:
 # means the ZDD will have 3 nodes, the node + the two terminal nodes
 mutable struct Node
     label::NodeEdge
-    comp::Array{UInt8, 1}       # can hold 256 possible values
+    comp::Vector{UInt8}       # can hold 256 possible values
     comp_weights::Vector{UInt8} # the max population of a component can only be 256
     cc::UInt8                   # can hold only 256 possible values
     fps::Set{ForbiddenPair}
@@ -45,22 +45,22 @@ mutable struct Node
     end
 
     function Node(i::Int)::Node # for Terminal Nodes
-        return new(NodeEdge(i, i), Array{UInt8, 1}(), Vector{UInt8}(), 0, Set{ForbiddenPair}(), Vector{UInt8}([]))
+        return new(NodeEdge(i, i), Vector{UInt8}(), Vector{UInt8}(), 0, Set{ForbiddenPair}(), Vector{UInt8}([]))
     end
 
     function Node(root_edge::NodeEdge, base_graph::SimpleGraph)::Node
         comp_assign = Vector{UInt8}([i for i in 1:nv(base_graph)])
         comp_weights = Vector{UInt8}([1 for i in 1:nv(base_graph)]) # initialize each vertex's population to be 1.
-        return new(root_edge, Array{UInt8, 1}(), comp_weights, 0, Set{ForbiddenPair}(), comp_assign)
+        return new(root_edge, Vector{UInt8}(), comp_weights, 0, Set{ForbiddenPair}(), comp_assign)
     end
 
-    function Node(label::NodeEdge, comp::Array{UInt8, 1}, comp_weights::Vector{UInt8},
+    function Node(label::NodeEdge, comp::Vector{UInt8}, comp_weights::Vector{UInt8},
                   cc::UInt8, fps::Set{ForbiddenPair}, comp_assign::Vector{UInt8})::Node
         return new(label, comp, comp_weights, cc, fps, comp_assign)
     end
 end
 
-function copy_to_vec!(vec₁::Vector{UInt8}, vec₂::Vector{UInt8})
+function copy_to_vec!(vec₁::Vector{T}, vec₂::Vector{T}) where T
     """ Copy items from vec₁ into vec₂.
         It is assumed that length(vec₂) >= length(vec₁)
     """
@@ -69,7 +69,7 @@ function copy_to_vec!(vec₁::Vector{UInt8}, vec₂::Vector{UInt8})
     end
 end
 
-function copy_to_set!(set₁::Set{ForbiddenPair}, set₂::Set{ForbiddenPair})
+function copy_to_set!(set₁::Set{T}, set₂::Set{T}) where T
     for item in set₁
         push!(set₂, item)
     end

--- a/ZDD/jl_zdd/run_algo.jl
+++ b/ZDD/jl_zdd/run_algo.jl
@@ -12,7 +12,7 @@ function run_algo(dim, k, d)
 # to compile it the first time round
     # println("Making a small ZDD for compiling purposes")
     g = grid([dim, dim])
-    g_edges = optimal_grid_edge_order(g, dim, dim)
+    g_edges = optimal_grid_edge_order_diags(g, dim, dim)
     g_edges = convert_lightgraphs_edges_to_node_edges(g_edges)
     zdd = construct_zdd(g, k, d, g_edges)
 end

--- a/ZDD/jl_zdd/test_zdd.jl
+++ b/ZDD/jl_zdd/test_zdd.jl
@@ -6,7 +6,7 @@ include("zdd.jl")
 println("*")
 
 ### Compiling `construct_zdd()` ###
-grid_edges = convert_lightgraphs_edges_to_node_edges(optimal_grid_edge_order(grid([2,2]), 2, 2))
+grid_edges = convert_lightgraphs_edges_to_node_edges(optimal_grid_edge_order_diags(grid([2,2]), 2, 2))
 construct_zdd(grid([2,2]), 2, 0, grid_edges); nothing
 ###
 
@@ -45,7 +45,7 @@ for contiguity ∈ contiguities
             global tests += 1
             if contiguity == "rook"
                 g = grid([n,n])
-                g_edges = optimal_grid_edge_order(g, n, n)
+                g_edges = optimal_grid_edge_order_diags(g, n, n)
             else
                 g = queen_grid([n,n])
                 g_edges = optimal_queen_grid_edge_order(g, n, n)

--- a/ZDD/jl_zdd/zdd.jl
+++ b/ZDD/jl_zdd/zdd.jl
@@ -169,7 +169,7 @@ function make_new_node(g::SimpleGraph,
     for a in prev_frontier
         if a ∉ curr_frontier
             a_comp = n′.comp_assign[a]
-            if a_comp in n′.comp && length(filter(x -> x == a_comp, n′.comp_assign)) == 1
+            if a_comp in n′.comp && count(x -> x == a_comp, n′.comp_assign) == 1
                 if n′.comp_weights[a_comp] < lower_bound
                     return zero_terminal
                 end
@@ -258,7 +258,7 @@ function remove_vertex_from_node_fps!(node::Node, vertex::UInt8, fp_container::V
     vertex_comp = node.comp_assign[vertex]
 
     for fp in node.fps
-        if (vertex_comp == fp.comp₁ || vertex_comp == fp.comp₂) && length(filter(x -> x == vertex_comp, node.comp_assign)) == 1
+        if (vertex_comp == fp.comp₁ || vertex_comp == fp.comp₂) && count(x -> x == vertex_comp, node.comp_assign) == 1
             delete!(node.fps, fp)
             filter!(x -> x != vertex_comp, node.comp)
         end

--- a/ZDD/jl_zdd/zdd.jl
+++ b/ZDD/jl_zdd/zdd.jl
@@ -60,8 +60,6 @@ function add_zdd_edge!(zdd::ZDD,
 
     # add to simple graph
     add_edge!(zdd.graph, node₁_idx, node₂_idx)
-
-    nothing
 end
 
 function num_edges(zdd::ZDD)
@@ -202,7 +200,6 @@ function add_vertex_as_component!(n′::Node, vertex::UInt8, prev_frontier::Set{
         push!(n′.comp, vertex)
         sort!(n′.comp) # needed for Node equality to increase Node merges
     end
-    nothing
 end
 
 function replace_components_with_union!(node::Node, Cᵤ::UInt8, Cᵥ::UInt8, fp_container::Vector{ForbiddenPair})
@@ -257,57 +254,22 @@ function remove_vertex_from_node_fps!(node::Node, vertex::UInt8, fp_container::V
     """
     vertex_comp = node.comp_assign[vertex]
 
+    if count(x -> x == vertex_comp, node.comp_assign) != 1
+        node.comp_assign[vertex] = 0
+        return
+    end
+
     for fp in node.fps
-        if (vertex_comp == fp.comp₁ || vertex_comp == fp.comp₂) && count(x -> x == vertex_comp, node.comp_assign) == 1
-            delete!(node.fps, fp)
+        if (vertex_comp == fp.comp₁ || vertex_comp == fp.comp₂)
+            push!(fp_container, fp)
             filter!(x -> x != vertex_comp, node.comp)
         end
     end
+    for fp in fp_container
+        delete!(node.fps, fp)
+    end
 
     node.comp_assign[vertex] = 0
-    adjust_node!(node, vertex_comp, fp_container)
-end
-
-function adjust_node!(node::Node, vertex_comp::UInt8, fp_container::Vector{ForbiddenPair})
-    """
-    """
-    if vertex_comp in node.comp_assign
-        # there is atleast one lower vertex number that has the higher comp
-        # number and needs to be adjusted
-        lower_vertices = findall(x->x==vertex_comp, node.comp_assign)
-        new_max = maximum(lower_vertices)
-
-        # change comp.assign
-        for v in lower_vertices
-            node.comp_assign[v] = new_max
-        end
-
-        # change comp
-        filter!(x -> x != vertex_comp, node.comp)
-        push!(node.comp, new_max)
-        sort!(node.comp) # needed for Node equality to increase Node merges
-
-        if new_max != vertex_comp
-            node.comp_weights[new_max] = node.comp_weights[vertex_comp]
-            node.comp_weights[vertex_comp] = 0
-        end
-
-        # change ForbiddenPair
-        for fp in node.fps
-            if vertex_comp == fp.comp₁
-                other = fp.comp₂
-                delete!(node.fps, fp)
-                push!(fp_container, ForbiddenPair(min(new_max, other), max(new_max, other)))
-            elseif vertex_comp == fp.comp₂
-                other = fp.comp₁
-                delete!(node.fps, fp)
-                push!(fp_container, ForbiddenPair(min(new_max, other), max(new_max, other)))
-            end
-        end
-        for fp in fp_container
-            push!(node.fps, fp)
-        end
-    end
     empty!(fp_container)
 end
 

--- a/ZDD/jl_zdd/zdd_jl.ipynb
+++ b/ZDD/jl_zdd/zdd_jl.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 138,
    "metadata": {},
    "outputs": [
     {
@@ -33,7 +33,7 @@
        "add_zdd_node_and_edge! (generic function with 1 method)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 138,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -45,20 +45,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  6.275306 seconds (13.55 M allocations: 1.231 GiB, 22.62% gc time)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# grid graph\n",
-    "m = 6\n",
+    "m = 7\n",
     "dims = [m, m]\n",
     "k = m\n",
     "d = 0\n",
@@ -70,7 +62,7 @@
     "    g_edges = shuffle!(collect(edges(g)))\n",
     "else\n",
     "    g = grid(dims)\n",
-    "    g_edges = optimal_grid_edge_order(g, dims[1], dims[2])\n",
+    "    g_edges = optimal_grid_edge_order_diags(g, dims[1], dims[2])\n",
     "end\n",
     "\n",
     "g_edges = convert_lightgraphs_edges_to_node_edges(g_edges)\n",
@@ -80,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 144,
    "metadata": {},
    "outputs": [
     {
@@ -89,13 +81,213 @@
        "451206"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 144,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "count_paths(zdd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Node(NodeEdge(0x00, 0x00), UInt8[], UInt8[], 0x00, Set{ForbiddenPair}(), UInt8[])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n = Node(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Variables\n",
+      "  #self#\u001b[36m::Core.Compiler.Const(adjust_node!, false)\u001b[39m\n",
+      "  node\u001b[36m::Node\u001b[39m\n",
+      "  vertex_comp\u001b[36m::UInt8\u001b[39m\n",
+      "  fp_container\u001b[36m::Array{ForbiddenPair,1}\u001b[39m\n",
+      "  #235\u001b[36m::var\"#235#237\"{UInt8}\u001b[39m\n",
+      "  #236\u001b[36m::var\"#236#238\"{UInt8}\u001b[39m\n",
+      "  lower_vertices\u001b[36m::Array{Int64,1}\u001b[39m\n",
+      "  new_max\u001b[36m::Int64\u001b[39m\n",
+      "  @_9\u001b[33m\u001b[1m::Union{Nothing, Tuple{Int64,Int64}}\u001b[22m\u001b[39m\n",
+      "  @_10\u001b[33m\u001b[1m::Union{Nothing, Tuple{ForbiddenPair,Int64}}\u001b[22m\u001b[39m\n",
+      "  @_11\u001b[33m\u001b[1m::Union{Nothing, Tuple{ForbiddenPair,Int64}}\u001b[22m\u001b[39m\n",
+      "  v\u001b[36m::Int64\u001b[39m\n",
+      "  fp@_13\u001b[36m::ForbiddenPair\u001b[39m\n",
+      "  other\u001b[36m::UInt8\u001b[39m\n",
+      "  fp@_15\u001b[36m::ForbiddenPair\u001b[39m\n",
+      "\n",
+      "Body\u001b[36m::Array{ForbiddenPair,1}\u001b[39m\n",
+      "\u001b[90m1 ──\u001b[39m        Core.NewvarNode(:(#235))\n",
+      "\u001b[90m│   \u001b[39m        Core.NewvarNode(:(#236))\n",
+      "\u001b[90m│   \u001b[39m        Core.NewvarNode(:(lower_vertices))\n",
+      "\u001b[90m│   \u001b[39m        Core.NewvarNode(:(new_max))\n",
+      "\u001b[90m│   \u001b[39m        Core.NewvarNode(:(@_9))\n",
+      "\u001b[90m│   \u001b[39m        Core.NewvarNode(:(@_10))\n",
+      "\u001b[90m│   \u001b[39m        Core.NewvarNode(:(@_11))\n",
+      "\u001b[90m│   \u001b[39m %8   = Base.getproperty(node, :comp_assign)\u001b[36m::Array{UInt8,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %9   = (vertex_comp in %8)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #17 if not %9\n",
+      "\u001b[90m2 ──\u001b[39m %11  = Main.:(var\"#235#237\")\u001b[36m::Core.Compiler.Const(var\"#235#237\", false)\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %12  = Core.typeof(vertex_comp)\u001b[36m::Core.Compiler.Const(UInt8, false)\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %13  = Core.apply_type(%11, %12)\u001b[36m::Core.Compiler.Const(var\"#235#237\"{UInt8}, false)\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        (#235 = %new(%13, vertex_comp))\n",
+      "\u001b[90m│   \u001b[39m %15  = #235\u001b[36m::var\"#235#237\"{UInt8}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %16  = Base.getproperty(node, :comp_assign)\u001b[36m::Array{UInt8,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        (lower_vertices = Main.findall(%15, %16))\n",
+      "\u001b[90m│   \u001b[39m        Main.println(lower_vertices)\n",
+      "\u001b[90m│   \u001b[39m        (new_max = Main.maximum(lower_vertices))\n",
+      "\u001b[90m│   \u001b[39m %20  = lower_vertices\u001b[36m::Array{Int64,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        (@_9 = Base.iterate(%20))\n",
+      "\u001b[90m│   \u001b[39m %22  = (@_9 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %23  = Base.not_int(%22)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #5 if not %23\n",
+      "\u001b[90m3 ┄─\u001b[39m %25  = @_9::Tuple{Int64,Int64}\u001b[36m::Tuple{Int64,Int64}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        (v = Core.getfield(%25, 1))\n",
+      "\u001b[90m│   \u001b[39m %27  = Core.getfield(%25, 2)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %28  = Base.getproperty(node, :comp_assign)\u001b[36m::Array{UInt8,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %29  = new_max\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        Base.setindex!(%28, %29, v)\n",
+      "\u001b[90m│   \u001b[39m        (@_9 = Base.iterate(%20, %27))\n",
+      "\u001b[90m│   \u001b[39m %32  = (@_9 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %33  = Base.not_int(%32)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #5 if not %33\n",
+      "\u001b[90m4 ──\u001b[39m        goto #3\n",
+      "\u001b[90m5 ┄─\u001b[39m %36  = Main.:(var\"#236#238\")\u001b[36m::Core.Compiler.Const(var\"#236#238\", false)\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %37  = Core.typeof(vertex_comp)\u001b[36m::Core.Compiler.Const(UInt8, false)\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %38  = Core.apply_type(%36, %37)\u001b[36m::Core.Compiler.Const(var\"#236#238\"{UInt8}, false)\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        (#236 = %new(%38, vertex_comp))\n",
+      "\u001b[90m│   \u001b[39m %40  = #236\u001b[36m::var\"#236#238\"{UInt8}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %41  = Base.getproperty(node, :comp)\u001b[36m::Array{UInt8,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        Main.filter!(%40, %41)\n",
+      "\u001b[90m│   \u001b[39m %43  = Base.getproperty(node, :comp)\u001b[36m::Array{UInt8,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        Main.push!(%43, new_max)\n",
+      "\u001b[90m│   \u001b[39m %45  = Base.getproperty(node, :comp)\u001b[36m::Array{UInt8,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        Main.sort!(%45)\n",
+      "\u001b[90m│   \u001b[39m %47  = (new_max != vertex_comp)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #7 if not %47\n",
+      "\u001b[90m6 ──\u001b[39m %49  = Base.getproperty(node, :comp_weights)\u001b[36m::Array{UInt8,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %50  = Base.getindex(%49, vertex_comp)\u001b[36m::UInt8\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %51  = Base.getproperty(node, :comp_weights)\u001b[36m::Array{UInt8,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        Base.setindex!(%51, %50, new_max)\n",
+      "\u001b[90m│   \u001b[39m %53  = Base.getproperty(node, :comp_weights)\u001b[36m::Array{UInt8,1}\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        Base.setindex!(%53, 0, vertex_comp)\n",
+      "\u001b[90m7 ┄─\u001b[39m %55  = Base.getproperty(node, :fps)\u001b[36m::Set{ForbiddenPair}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        (@_10 = Base.iterate(%55))\n",
+      "\u001b[90m│   \u001b[39m %57  = (@_10 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %58  = Base.not_int(%57)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #14 if not %58\n",
+      "\u001b[90m8 ┄─\u001b[39m        Core.NewvarNode(:(other))\n",
+      "\u001b[90m│   \u001b[39m %61  = @_10::Tuple{ForbiddenPair,Int64}\u001b[36m::Tuple{ForbiddenPair,Int64}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        (fp@_13 = Core.getfield(%61, 1))\n",
+      "\u001b[90m│   \u001b[39m %63  = Core.getfield(%61, 2)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %64  = Base.getproperty(fp@_13, :comp₁)\u001b[36m::UInt8\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %65  = (vertex_comp == %64)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #10 if not %65\n",
+      "\u001b[90m9 ──\u001b[39m        (other = Base.getproperty(fp@_13, :comp₂))\n",
+      "\u001b[90m│   \u001b[39m %68  = Base.getproperty(node, :fps)\u001b[36m::Set{ForbiddenPair}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        Main.delete!(%68, fp@_13)\n",
+      "\u001b[90m│   \u001b[39m %70  = Main.min(new_max, other)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %71  = Main.max(new_max, other)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %72  = Main.ForbiddenPair(%70, %71)\u001b[36m::ForbiddenPair\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        Main.push!(fp_container, %72)\n",
+      "\u001b[90m└───\u001b[39m        goto #12\n",
+      "\u001b[90m10 ─\u001b[39m %75  = Base.getproperty(fp@_13, :comp₂)\u001b[36m::UInt8\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %76  = (vertex_comp == %75)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #12 if not %76\n",
+      "\u001b[90m11 ─\u001b[39m        (other = Base.getproperty(fp@_13, :comp₁))\n",
+      "\u001b[90m│   \u001b[39m %79  = Base.getproperty(node, :fps)\u001b[36m::Set{ForbiddenPair}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        Main.delete!(%79, fp@_13)\n",
+      "\u001b[90m│   \u001b[39m %81  = Main.min(new_max, other)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %82  = Main.max(new_max, other)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %83  = Main.ForbiddenPair(%81, %82)\u001b[36m::ForbiddenPair\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        Main.push!(fp_container, %83)\n",
+      "\u001b[90m12 ┄\u001b[39m        (@_10 = Base.iterate(%55, %63))\n",
+      "\u001b[90m│   \u001b[39m %86  = (@_10 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %87  = Base.not_int(%86)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #14 if not %87\n",
+      "\u001b[90m13 ─\u001b[39m        goto #8\n",
+      "\u001b[90m14 ┄\u001b[39m %90  = fp_container\u001b[36m::Array{ForbiddenPair,1}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        (@_11 = Base.iterate(%90))\n",
+      "\u001b[90m│   \u001b[39m %92  = (@_11 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %93  = Base.not_int(%92)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #17 if not %93\n",
+      "\u001b[90m15 ┄\u001b[39m %95  = @_11::Tuple{ForbiddenPair,Int64}\u001b[36m::Tuple{ForbiddenPair,Int64}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        (fp@_15 = Core.getfield(%95, 1))\n",
+      "\u001b[90m│   \u001b[39m %97  = Core.getfield(%95, 2)\u001b[36m::Int64\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %98  = Base.getproperty(node, :fps)\u001b[36m::Set{ForbiddenPair}\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m        Main.push!(%98, fp@_15)\n",
+      "\u001b[90m│   \u001b[39m        (@_11 = Base.iterate(%90, %97))\n",
+      "\u001b[90m│   \u001b[39m %101 = (@_11 === nothing)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m│   \u001b[39m %102 = Base.not_int(%101)\u001b[36m::Bool\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        goto #17 if not %102\n",
+      "\u001b[90m16 ─\u001b[39m        goto #15\n",
+      "\u001b[90m17 ┄\u001b[39m %105 = Main.empty!(fp_container)\u001b[36m::Array{ForbiddenPair,1}\u001b[39m\n",
+      "\u001b[90m└───\u001b[39m        return %105\n"
+     ]
+    }
+   ],
+   "source": [
+    "@code_warntype adjust_node!(n, UInt8(5), Vector{ForbiddenPair}())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "80"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@allocated Array{Nothing, 1}()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "96"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@allocated Vector{UInt8}(undef, 0)"
    ]
   },
   {


### PR DESCRIPTION
* optimized `replace_components_with_union()` function -- turns out that I was overlooking a small thing and had added much unnecessary complexity! I put the now unnecessary `adjust_node()` function and its underlings in a file called `graveyard.jl` (graveyard for that is where code goes to die...)
*  minor cleanups elsewhere.

They did get us somewhere though. 
Previously 6x6 was at `6.2s, 13.55 M allocations, 1.23 GB total` . With these changes we get to `5.6s, 11.62M allocations, 1.045GB total`. I believe this should bring increased speedups for 7x7 and also help us with RAM.