### PR TITLE
Recycler

### DIFF
--- a/ZDD/jl_zdd/node.jl
+++ b/ZDD/jl_zdd/node.jl
@@ -1,6 +1,5 @@
 # node.jl
 import Base: isequal, ==, isless, Dict
-using StaticArrays
 
 struct NodeEdge
     edge₁::UInt8

--- a/ZDD/jl_zdd/zdd_jl.ipynb
+++ b/ZDD/jl_zdd/zdd_jl.ipynb
@@ -2,14 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m\u001b[1m Activating\u001b[22m\u001b[39m environment at `~/.julia/environments/zdd/Project.toml`\n"
+      "\u001b[32m\u001b[1m Activating\u001b[22m\u001b[39m environment at `~/.julia/environments/zdd/Project.toml`\n",
+      "┌ Info: Precompiling BenchmarkTools [6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf]\n",
+      "└ @ Base loading.jl:1278\n"
      ]
     }
    ],
@@ -19,12 +21,13 @@
     "using GraphPlot\n",
     "using Compose\n",
     "using Random\n",
-    "using Traceur"
+    "using Traceur\n",
+    "using BenchmarkTools"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -33,7 +36,7 @@
        "add_zdd_node_and_edge! (generic function with 1 method)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -45,14 +48,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  3.357921 seconds (8.83 M allocations: 797.484 MiB, 27.77% gc time)\n"
+      "  3.387015 seconds (5.68 M allocations: 514.201 MiB, 22.38% gc time)\n"
      ]
     }
    ],
@@ -80,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [
     {
@@ -89,13 +92,33 @@
        "451206"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "count_paths(zdd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "553643"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nv(zdd.graph)"
    ]
   },
   {


### PR DESCRIPTION
Added a `Stack` that stores the `Node` objects that we don't need anymore (the "grandparent" nodes and reuses them for new nodes. 

This reduces the number of allocations by a lot. Previously 7x7 stood at:
```
927s, 308.2M allocations, 27.9 GB allocated total
```
After this change it stands at
```
854s, 184.48M allocations, 16.7 GB
```

I'm kinda disappointed that the speedup wasn't greater, especially considering that the number of allocations decreased by a third, but oh well.