### PR TITLE
Recycle Nodes at same level

### DIFF
--- a/ZDD/jl_zdd/node.jl
+++ b/ZDD/jl_zdd/node.jl
@@ -23,13 +23,11 @@ struct ForbiddenPair
     comp₂::UInt8
 end
 
-function Base.:(==)(fp_1::ForbiddenPair, fp_2::ForbiddenPair)
-    (fp_1.comp₁ == fp_2.comp₁) && (fp_1.comp₂ == fp_2.comp₂)
-end
+==(p::ForbiddenPair, q::ForbiddenPair) = (p.comp₁==q.comp₁) & (p.comp₂==q.comp₂)
 
-function Base.isless(fp_1::ForbiddenPair, fp_2::ForbiddenPair) # TODO: does this make sense???
-    fp_1.comp₁ < fp_2.comp₁
-end
+isequal(p::ForbiddenPair, q::ForbiddenPair) = isequal(p.comp₁,q.comp₁) & isequal(p.comp₂,q.comp₂)
+
+isless(p::ForbiddenPair, q::ForbiddenPair) = ifelse(!isequal(p.comp₁,q.comp₁), isless(p.comp₁,q.comp₁), isless(p.comp₂,q.comp₂))
 
 Base.hash(fp::ForbiddenPair, h::UInt) = hash(fp.comp₁, hash(fp.comp₂, h))
 
@@ -92,8 +90,10 @@ function copy_to_vec_from_idx!(vec₁::Vector{T}, vec₂::Vector{T}, idx::UInt8)
     end
 end
 
-function custom_deepcopy(n::Node, recycler::Stack{Node})::Node
-
+function custom_deepcopy(n::Node, recycler::Stack{Node}, x::Int8)::Node
+    if x == 1
+        return n
+    end
     if isempty(recycler)
         comp = Vector{UInt8}(undef, length(n.comp))
         comp_weights = Vector{UInt8}(undef, length(n.comp_weights))

--- a/ZDD/jl_zdd/node.jl
+++ b/ZDD/jl_zdd/node.jl
@@ -129,12 +129,11 @@ function custom_deepcopy(n::Node, recycler::Stack{Node}, x::Int8)::Node
 end
 
 function Base.:(==)(node₁::Node, node₂::Node)
-    node₁.cc == node₂.cc &&
-    node₁.comp_weights == node₂.comp_weights &&
-    node₁.label == node₂.label &&
-    node₁.comp == node₂.comp &&
-    node₁.fps == node₂.fps &&
-    node₁.comp_assign == node₂.comp_assign
+    node₁.hash == node₂.hash
+end
+
+function Base.isequal(node₁::Node, node₂::Node)
+    node₁.hash == node₂.hash
 end
 
 function Base.hash(n::Node, h::UInt)

--- a/ZDD/jl_zdd/zdd.jl
+++ b/ZDD/jl_zdd/zdd.jl
@@ -204,6 +204,7 @@ function make_new_node(g::SimpleGraph,
 
     if i == length(g_edges)
         if n′.cc == k
+            push!(recycler, n′)
             return one_terminal
         else
             push!(recycler, n′)

--- a/ZDD/jl_zdd/zdd_jl.ipynb
+++ b/ZDD/jl_zdd/zdd_jl.ipynb
@@ -2,16 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m\u001b[1m Activating\u001b[22m\u001b[39m environment at `~/.julia/environments/zdd/Project.toml`\n",
-      "┌ Info: Precompiling BenchmarkTools [6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf]\n",
-      "└ @ Base loading.jl:1278\n"
+      "\u001b[32m\u001b[1m Activating\u001b[22m\u001b[39m environment at `~/.julia/environments/zdd/Project.toml`\n"
      ]
     }
    ],
@@ -27,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -36,7 +34,7 @@
        "add_zdd_node_and_edge! (generic function with 1 method)"
       ]
      },
-     "execution_count": 184,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -48,14 +46,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "725.916941 seconds (93.96 M allocations: 8.306 GiB, 3.06% gc time)\n"
+      "727.036745 seconds (93.96 M allocations: 8.306 GiB, 3.16% gc time)\n"
      ]
     }
    ],
@@ -83,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -92,7 +90,7 @@
        "158753814"
       ]
      },
-     "execution_count": 198,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -103,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -112,7 +110,7 @@
        "18036242"
       ]
      },
-     "execution_count": 199,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/ZDD/jl_zdd/zdd_jl.ipynb
+++ b/ZDD/jl_zdd/zdd_jl.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 184,
    "metadata": {},
    "outputs": [
     {
@@ -36,7 +36,7 @@
        "add_zdd_node_and_edge! (generic function with 1 method)"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 184,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -48,20 +48,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 197,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  3.387015 seconds (5.68 M allocations: 514.201 MiB, 22.38% gc time)\n"
+      "725.916941 seconds (93.96 M allocations: 8.306 GiB, 3.06% gc time)\n"
      ]
     }
    ],
    "source": [
     "# grid graph\n",
-    "m = 6\n",
+    "m = 7\n",
     "dims = [m, m]\n",
     "k = m\n",
     "d = 0\n",
@@ -83,16 +83,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 198,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "451206"
+       "158753814"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 198,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -103,16 +103,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 199,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "553643"
+       "18036242"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 199,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
I realized that you can actually recycle nodes at the same level too. 

In the code chunk
```
for x in [0, 1] 
   ... 
   make_new_node()
   ...
```
When x == 0 is complete you can actually use the parent node used here and _modify_ it when x == 1 i.e instead of deepcopying it you actually modify it because you don' t need this node anymore ever.

Also, whenever you get to a terminal node, you don't need to discard the node you have been building so far, you can just dump it into the recycling bin. 

These changes take us from 
```
746s, 144.86M allocations, 13.3 GB total, 4.91%gc
```
to:
```
725s, 93.96M allocations, 8.3 GB total, 3%gc
```
This isn't a huge jump timewise, which honestly shocks me, but it is what it is.

 