### PR TITLE
Fix node.first_idx

### DIFF
--- a/ZDD/jl_zdd/graveyard.jl
+++ b/ZDD/jl_zdd/graveyard.jl
@@ -38,3 +38,11 @@ function add_vertex_as_component!(n′::Node, vertex::UInt8, prev_frontier::Set{
         push!(n′.comp, vertex)
     end
 end
+
+function first_non_zero(vec::Vector{UInt8})::UInt8
+    for (i, item) in enumerate(vec)
+        if item != 0
+            return UInt8(i)
+        end
+    end
+end

--- a/ZDD/jl_zdd/node.jl
+++ b/ZDD/jl_zdd/node.jl
@@ -95,7 +95,7 @@ function custom_deepcopy(n::Node, recycler::Stack{Node}, x::Int8)::Node
     end
     if isempty(recycler)
         comp_weights = Vector{UInt8}(undef, length(n.comp_weights))
-        comp_assign = Vector{UInt8}(undef, length(n.comp_assign))
+        comp_assign = zeros(UInt8, length(n.comp_assign))
         fps = Vector{ForbiddenPair}(undef, length(n.fps))
 
         copy_to_vec_from_idx!(n.comp_weights, comp_weights, n.first_idx)

--- a/ZDD/jl_zdd/weightless_node.jl
+++ b/ZDD/jl_zdd/weightless_node.jl
@@ -89,10 +89,9 @@ function custom_deepcopy(n::Node, recycler::Stack{Node}, x::Int8)::Node
         return n
     end
     if isempty(recycler)
-        comp_assign = Vector{UInt8}(undef, length(n.comp_assign))
+        comp_assign = zeros(UInt8, length(n.comp_assign))
         fps = Vector{ForbiddenPair}(undef, length(n.fps))
 
-        # copy_to_vec!(n.comp, comp)
         copy_to_vec_from_idx!(n.comp_assign, comp_assign, n.first_idx)
         copy_to_vec!(n.fps, fps)
 

--- a/ZDD/jl_zdd/weightless_zdd.jl
+++ b/ZDD/jl_zdd/weightless_zdd.jl
@@ -180,7 +180,6 @@ function make_new_node(g::SimpleGraph,
         end
     end
 
-    n′.first_idx = first_non_zero(n′.comp_assign)
     for a in prev_frontier
         if a ∉ curr_frontier
             @inbounds a_comp = n′.comp_assign[a]
@@ -205,14 +204,6 @@ function make_new_node(g::SimpleGraph,
         end
     end
     return n′
-end
-
-function first_non_zero(vec::Vector{UInt8})::UInt8
-    for (i, item) in enumerate(vec)
-        if i != 0
-            return UInt8(i)
-        end
-    end
 end
 
 function replace_components_with_union!(
@@ -286,6 +277,10 @@ function remove_vertex_from_node!(node::Node, vertex::UInt8, fp_container::Vecto
     elseif c > 1
         @inbounds node.comp_assign[vertex] = 0
         adjust_node!(node, vertex_comp, fp_container, rm_container, lower_vs)
+    end
+
+    if vertex == node.first_idx
+        node.first_idx += 1
     end
 end
 

--- a/ZDD/jl_zdd/zdd.jl
+++ b/ZDD/jl_zdd/zdd.jl
@@ -182,8 +182,6 @@ function make_new_node(g::SimpleGraph,
         end
     end
 
-    n′.first_idx = first_non_zero(n′.comp_assign)
-
     for a in prev_frontier
         if a ∉ curr_frontier
             @inbounds a_comp = n′.comp_assign[a]
@@ -216,14 +214,6 @@ function make_new_node(g::SimpleGraph,
     end
 
     return n′
-end
-
-function first_non_zero(vec::Vector{UInt8})::UInt8
-    for (i, item) in enumerate(vec)
-        if i != 0
-            return UInt8(i)
-        end
-    end
 end
 
 function replace_components_with_union!(
@@ -298,6 +288,9 @@ function remove_vertex_from_node!(node::Node, vertex::UInt8, fp_container::Vecto
     elseif c > 1
         @inbounds node.comp_assign[vertex] = 0
         adjust_node!(node, vertex_comp, fp_container, rm_container, lower_vs)
+    end
+    if vertex == node.first_idx
+        node.first_idx += 1
     end
 end
 

--- a/ZDD/jl_zdd/zdd_jl.ipynb
+++ b/ZDD/jl_zdd/zdd_jl.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -34,32 +34,24 @@
        "add_zdd_node_and_edge! (generic function with 1 method)"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "include(\"weightless_zdd.jl\")\n",
-    "# include(\"zdd.jl\")"
+    "# include(\"weightless_zdd.jl\")\n",
+    "include(\"zdd.jl\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1.115648 seconds (2.13 M allocations: 177.078 MiB, 12.51% gc time)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# grid graph\n",
-    "m = 6\n",
+    "m = 7\n",
     "dims = [m, m]\n",
     "k = m\n",
     "d = 0\n",
@@ -81,40 +73,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "356612826084"
-      ]
-     },
-     "execution_count": 111,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "count_paths(zdd)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "317986"
-      ]
-     },
-     "execution_count": 112,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nv(zdd.graph)"
    ]

--- a/ZDD/jl_zdd/zdd_jl.ipynb
+++ b/ZDD/jl_zdd/zdd_jl.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [
     {
@@ -34,26 +34,26 @@
        "add_zdd_node_and_edge! (generic function with 1 method)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# include(\"weightless_zdd.jl\")\n",
-    "include(\"zdd.jl\")"
+    "include(\"weightless_zdd.jl\")\n",
+    "# include(\"zdd.jl\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  2.388515 seconds (2.83 M allocations: 258.530 MiB, 10.48% gc time)\n"
+      "  1.115648 seconds (2.13 M allocations: 177.078 MiB, 12.51% gc time)\n"
      ]
     }
    ],
@@ -81,16 +81,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "451206"
+       "356612826084"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -101,16 +101,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "541069"
+       "317986"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -118,6 +118,13 @@
    "source": [
     "nv(zdd.graph)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Fixes node.first_idx for both the weighted and weightless ZDDs, which previously seems to have been broken