### PR TITLE
add possibility for population info

### DIFF
--- a/ZDD/jl_zdd/node.jl
+++ b/ZDD/jl_zdd/node.jl
@@ -57,9 +57,9 @@ mutable struct Node
         return node
     end
 
-    function Node(root_edge::NodeEdge, base_graph::SimpleGraph)::Node
+    function Node(root_edge::NodeEdge, base_graph::SimpleGraph, weights::Vector{UInt8})::Node
         comp_assign = Vector{UInt8}([i for i in 1:nv(base_graph)])
-        comp_weights = Vector{UInt8}([1 for i in 1:nv(base_graph)]) # initialize each vertex's population to be 1.
+        comp_weights = weights # initialize each vertex's population based on user input
         node = new(root_edge, comp_weights, 0, Vector{ForbiddenPair}(), comp_assign, true, UInt8(1), 0, 1)
         node.hash = hash(node)
         return node

--- a/ZDD/jl_zdd/zdd.jl
+++ b/ZDD/jl_zdd/zdd.jl
@@ -72,11 +72,14 @@ function construct_zdd(g::SimpleGraph,
                        k::Int64,
                        d::Int64,
                        g_edges::Array{NodeEdge,1};
+                       weights::Vector{Int64}=Vector{Int64}([1 for i in 1:nv(g)]),
                        viz::Bool=false)::ZDD
-    root = Node(g_edges[1], g)
+    weights = [convert(UInt8,i) for i in weights]
+    root = Node(g_edges[1], g, weights)
 
-    lower_bound = Int8(nv(g)/k - d) # TODO: extend to non-nice ratios
-    upper_bound = Int8(nv(g)/k + d)
+    lower_bound = Int8(floor(sum(weights)/k - d)) # TODO: extend to non-nice ratios
+    upper_bound = Int8(floor(sum(weights)/k + d))
+    println("Accepting districts with population in [$lower_bound, $upper_bound]")
 
     zdd = ZDD(g, root, viz=viz)
     N = Vector{Set{Node}}([Set{Node}([]) for a in 1:ne(g)+1])


### PR DESCRIPTION
This small PR adds the functionality to pass a `weights` vector into the `construct_zdd()` function, where each element in `weights` corresponds to the population of a vertex in the base graph. The changes are as follows:

- Change the `Node()` initialization function in `node.jl` to initialize `comp_weights` to `weights`.
- Add an optional parameter into the `construct_zdd()` function in `zdd.jl`. This defaults to a vector of ones, corresponding to a unit-weight input graph. For the user's convenience, this parameter has type `Vector{Int64}`, but is immediately converted to `Vector{UInt8}`, which I assume(?) will help speed things up.
- Slightly modify the `lower_bound` and `upper_bound` lines in `construct_zdd()` to incorporate the `weights` vector in their calculations. 

Note that we now `floor()` the total population / k to avoid an `InexactError`. I don't have a clear normative reason to use `floor()` over `ceil()`, but this makes the bounds work the way I'd expect them to for some non-unit weight examples. I added a short print statement that shows the users the bounds for debugging purposes.