### PR TITLE
Two-Way ZDD!

### DIFF
--- a/ZDD/jl_zdd/node_auxillaries.jl
+++ b/ZDD/jl_zdd/node_auxillaries.jl
@@ -38,6 +38,10 @@ function readable(arr::Vector{UInt8})::Array{Int64, 1}
     Array{Int, 1}([Int64(x) for x in arr])
 end
 
+function readable(arr::Vector{UInt32})::Array{Int64, 1}
+    Array{Int, 1}([Int64(x) for x in arr])
+end
+
 function readable(cc::UInt8)::Int64
     Int64(cc)
 end

--- a/ZDD/jl_zdd/two_way_zdd.jl
+++ b/ZDD/jl_zdd/two_way_zdd.jl
@@ -1,0 +1,171 @@
+include("zdd.jl")
+
+function construct_half_zdd(g::SimpleGraph,
+                            k::Int64, # can we change this to Int8? should we?
+                            d::Int64,
+                            g_edges::Array{NodeEdge,1},
+                            weights::Vector{Int64}=Vector{Int64}([1 for i in 1:nv(g)]),
+                            viz::Bool=false,
+                            save_fp::String="zdd_tree.txt")::Set{Node}
+
+    # delete file if it already exists
+    if isfile(save_fp)
+        rm(save_fp)
+    end
+
+    weights = Vector{UInt32}([convert(UInt32,i) for i in weights])
+    root = Node(g_edges[1], g, weights)
+
+    lower_bound = Int32(floor(sum(weights)/k - d))
+    upper_bound = Int32(floor(sum(weights)/k + d))
+
+    println("Constructing a half-ZDD...")
+
+    zdd = ZDD(g, root, viz=viz)
+    halfway = Int(ne(g)/2)
+    N = Vector{Set{Node}}([Set{Node}([]) for a in 1:halfway+1])
+    N[1] = Set([root]) # why not Set(root)
+    frontiers = compute_all_frontiers(g, g_edges) # only need to do half...
+    xs = Vector{Int8}([0,1])
+    zero_terminal = Node(0)
+    one_terminal = Node(1)
+    fp_container = Vector{ForbiddenPair}([])
+    rm_container = Vector{ForbiddenPair}([])
+    reusable_set = Set{ForbiddenPair}([])
+    recycler = Stack{Node}() # what is this?
+    lower_vs = Vector{UInt8}([])
+
+    for i = 1:halfway
+        for n in N[i]
+            n_idx = zdd.nodes[n.hash]
+            for x in xs
+                n′ = make_new_node(g, g_edges, k, n, i, x, d, frontiers,
+                                   lower_bound, upper_bound,
+                                   zero_terminal, one_terminal,
+                                   fp_container, rm_container, lower_vs, recycler)
+
+                if n′ === one_terminal
+                    zdd.paths += n.paths
+                end
+
+                if !(n′.label == NodeEdge(0,0) || n′.label == NodeEdge(1,1)) # if not a Terminal Node
+                    n′.label = g_edges[i+1] #  update the label of n′
+                    reusable_unique!(n′.fps, reusable_set)
+                    sort!(n′.fps, alg=QuickSort)
+                    n′.hash = hash(n′)
+
+                    if n′ in N[i+1]
+                        index = Base.ht_keyindex2!(N[i+1].dict, n′)
+                        N[i+1].dict.keys[index].paths += n.paths
+                    else
+                        add_zdd_node_and_edge!(zdd, n′, n, n_idx, x)
+                        push!(N[i+1], n′)
+                        continue
+                    end
+                end
+                add_zdd_edge!(zdd, n, n′, n_idx, x) # the order of n and n′ are switched, but probably ok
+            end
+        end
+        if i == halfway
+            return N[i+1]
+        end
+        zdd.deleted_nodes += length(N[i])
+        save_tree_so_far!(zdd, save_fp, length(N[i]))
+        erase_upper_levels!(zdd, N[i+1], zero_terminal, one_terminal, length(N[i])) # release memory
+        N[i] = Set{Node}([])   # release memory
+        # println(i, ": ", Base.summarysize(zdd))
+    end
+    # return zdd
+end
+                
+function all_vertices_connected_to(v, node)
+    representative_vertex = node.comp_assign[v]
+    return Set(findall(==(representative_vertex), node.comp_assign))
+end
+
+function setup(fnode, bnode, frontier)
+    fcomp, bcomp, intcomp = Dict(), Dict(), Dict() # add type annotations
+    ffrontier, bfrontier, frontier_span = Dict(), Dict(), Dict() # add type annotations
+    isolated_frontier_vtxs = Set()
+    
+    for v ∈ frontier
+        fcomp[v] = all_vertices_connected_to(v, fnode)
+        bcomp[v] = all_vertices_connected_to(v, bnode)
+        intcomp[v] = intersect(fcomp[v],bcomp[v])
+        
+        ffrontier[v] = intersect(fcomp[v], frontier)
+        bfrontier[v] = intersect(bcomp[v], frontier)
+        frontier_span[v] = union(ffrontier[v], bfrontier[v])
+        
+        push!(isolated_frontier_vtxs, maximum(frontier_span[v]))
+    end
+    return fcomp, bcomp, intcomp, isolated_frontier_vtxs
+end
+
+function check_weights(fcomp, bcomp, intcomp, frontier, acceptable, w)
+    for v ∈ frontier
+        if !(w(fcomp[v]) + w(bcomp[v]) - w(intcomp[v]) ∈ acceptable)
+            return false
+        end
+    end
+    return true
+end
+        
+function check_fps(fnode, bnode, fcomp, bcomp, intcomp, frontier)
+    for v ∈ frontier
+        for x ∈ fcomp[v]
+            for y ∈ bcomp[v]
+                if (x,y) ∈ union(fnode.fps, bnode.fps)
+                    return false
+                end
+            end
+        end
+    end
+    return true
+end
+
+function check_cc(fnode, bnode, k, isolated_frontier_vtxs)
+    if fnode.cc + bnode.cc + length(isolated_frontier_vtxs) == k
+        return true
+    end
+    return false
+end
+
+function is_compatible(fnode, bnode, frontier, acceptable, w, k, checking)
+    fcomp, bcomp, intcomp, isolated_frontier_vtxs = setup(fnode, bnode, frontier)
+    weights = check_weights(fcomp, bcomp, intcomp, frontier, acceptable, w)
+    fps = check_fps(fnode, bnode, fcomp, bcomp, intcomp, frontier)
+    cc = check_cc(fnode, bnode, k, isolated_frontier_vtxs)
+    
+    checklist = []
+    if "weights" ∈ checking
+        push!(checklist, weights)
+    end
+    if "fps" ∈ checking
+        push!(checklist, fps)
+    end
+    if "cc" ∈ checking
+        push!(checklist, cc)
+    end
+    if all(checklist)
+        return true
+    end
+    return false
+end
+
+function w(v)
+    return 1
+end
+
+function number_compatible(fnodes, bnodes, frontier, acceptable, w, k, checking)
+    println("Total # of node pairs: $(length(fnodes)) * $(length(bnodes)) = $(length(fnodes) * length(bnodes))")
+    num_partitions = 0
+    for fnode ∈ fnodes
+        for bnode ∈ bnodes
+            if is_compatible(fnode, bnode, frontier, acceptable, w, k, checking)
+                num_partitions += 1
+            end
+        end
+    end
+    return num_partitions
+end

--- a/ZDD/jl_zdd/weighted.jl
+++ b/ZDD/jl_zdd/weighted.jl
@@ -11,6 +11,7 @@ include("edge_ordering.jl")
 include("zdd.jl")
 include("count_enumerate.jl")
 include("visualization.jl")
+include("two_way_zdd.jl")
 
 
 function make_new_node(g::SimpleGraph,

--- a/ZDD/jl_zdd/weighted_node.jl
+++ b/ZDD/jl_zdd/weighted_node.jl
@@ -43,7 +43,6 @@ function custom_deepcopy(n::Node, recycler::Stack{Node}, x::Int8)::Node
         return n
     end
     if isempty(recycler)
-        # comp_weights = Vector{UInt32}(undef, length(n.comp_weights))
         comp_weights = zeros(UInt32, length(n.comp_weights))
         comp_assign = zeros(UInt8, length(n.comp_assign))
         fps = Vector{ForbiddenPair}(undef, length(n.fps))

--- a/ZDD/jl_zdd/weighted_node.jl
+++ b/ZDD/jl_zdd/weighted_node.jl
@@ -43,7 +43,8 @@ function custom_deepcopy(n::Node, recycler::Stack{Node}, x::Int8)::Node
         return n
     end
     if isempty(recycler)
-        comp_weights = Vector{UInt32}(undef, length(n.comp_weights))
+        # comp_weights = Vector{UInt32}(undef, length(n.comp_weights))
+        comp_weights = zeros(UInt32, length(n.comp_weights))
         comp_assign = zeros(UInt8, length(n.comp_assign))
         fps = Vector{ForbiddenPair}(undef, length(n.fps))
 

--- a/ZDD/jl_zdd/weightless.jl
+++ b/ZDD/jl_zdd/weightless.jl
@@ -10,6 +10,7 @@ include("edge_ordering.jl")
 include("zdd.jl")
 include("count_enumerate.jl")
 include("visualization.jl")
+include("two_way_zdd.jl")
 
 
 function make_new_node(g::SimpleGraph,

--- a/ZDD/jl_zdd/zdd_jl.ipynb
+++ b/ZDD/jl_zdd/zdd_jl.ipynb
@@ -9,11 +9,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m\u001b[1m Activating\u001b[22m\u001b[39m environment at `~/.julia/environments/zdd/Project.toml`\n",
-      "┌ Info: Precompiling GraphPlot [a2cc645c-3eea-5389-862e-a155d0052231]\n",
-      "└ @ Base loading.jl:1278\n",
-      "┌ Info: Precompiling BenchmarkTools [6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf]\n",
-      "└ @ Base loading.jl:1278\n"
+      "\u001b[32m\u001b[1m Activating\u001b[22m\u001b[39m new environment at `~/.julia/environments/zdd/Project.toml`\n"
      ]
     }
    ],
@@ -29,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -38,7 +34,7 @@
        "adjust_node! (generic function with 1 method)"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -46,6 +42,75 @@
    "source": [
     "# include(\"weightless.jl\")\n",
     "include(\"weighted.jl\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Constructing a half-ZDD...\n",
+      " 15.644982 seconds (16.00 M allocations: 1.242 GiB, 6.91% gc time)\n",
+      "Constructing a half-ZDD...\n",
+      " 16.198733 seconds (16.00 M allocations: 1.242 GiB, 8.26% gc time)\n"
+     ]
+    }
+   ],
+   "source": [
+    "m = 7\n",
+    "dims = [m,m]\n",
+    "k = m\n",
+    "d = 0\n",
+    "g = grid(dims)\n",
+    "g_edges = optimal_grid_edge_order_diags(g, dims[1], dims[2])\n",
+    "forwards = convert_lightgraphs_edges_to_node_edges(g_edges)\n",
+    "backwards = reverse(forwards)\n",
+    "\n",
+    "frontiers = compute_all_frontiers(g, forwards)\n",
+    "middle_frontier = frontiers[Int(ceil(length(frontiers)/2))]\n",
+    "\n",
+    "# @time zdd = construct_zdd(g, k, d, forwards)\n",
+    "@time fnodes = construct_half_zdd(g, k, d, forwards)\n",
+    "@time bnodes = construct_half_zdd(g, k, d, backwards); nothing\n",
+    "# count_paths(zdd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "number_compatible (generic function with 2 methods)"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_three = [\"weights\", \"fps\", \"cc\"]\n",
+    "weights = [\"weights\"] # none seem to work\n",
+    "fps = [\"fps\"] # all seem to work\n",
+    "cc = [\"cc\"] # 40/81 work\n",
+    "weights_fps = [\"weights\", \"fps\"]\n",
+    "weights_cc = [\"weights\", \"cc\"]\n",
+    "fps_cc = [\"fps\", \"cc\"]\n",
+    "@time number_compatible(fnodes, bnodes, middle_frontier, 4:4, w, k, all_three)"
    ]
   },
   {
@@ -133,7 +198,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.5.3",
+   "display_name": "Julia 1.5.1",
    "language": "julia",
    "name": "julia-1.5"
   },
@@ -141,7 +206,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.5.3"
+   "version": "1.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The majority of this PR involves adding `two_way_zdd.jl`, which creates the following functions:
- `construct_halfway_zdd()` which is identical to `construct_zdd()` except it returns the list of Nodes at precisely the halfway point along the ZDD
- `number_compatible()` which takes the two lists of nodes as given by `construct_halfway_zdd()` and some other arguments, and uses helper functions in `two_way_zdd.jl` to calculate the number of compatible pairs of "forward" and "backward" nodes. This number should be equal to the number of solutions to the whole ZDD.

This PR amends the `zdd_jl.ipynb` notebook to provide an example of using this new function. At present, it doesn't work — the number of compatible pairs doesn't match what we'd expect, and you can play around with checking how many pairs are `weight`-compatible only, `fps`-compatible, or `cc`-compatible, which might be helpful for debugging purposes.

Some additional changes this PR made that are not relevant to Two-Way:
- Added a `readable()` function for `comp_weights`
- Changed `comp_weights` in the recycler to initialize all weights to 0 (rather than undefined)